### PR TITLE
Improve blank line handling

### DIFF
--- a/src/parse_utils.rs
+++ b/src/parse_utils.rs
@@ -5,7 +5,7 @@ use combine::Stream;
 use combine::ParseError;
 
 use combine::char::newline;
-use combine::{Parser, many, many1, none_of, try};
+use combine::{Parser, many, many1, none_of, try, eof};
 
 /// Match a single non-newline character
 ///
@@ -31,9 +31,9 @@ where I: Stream<Item = char>,
     none_of("\r\n".chars())
 }
 
-/// Parse one or more characters up to the next newline character, consuming it.
-/// Return the characters consumed on the way to the newline, but not the
-/// newline.
+/// Parse one or more characters up to the next newline character (or until
+/// eof), consuming it. Return the characters consumed on the way to the
+/// newline, but not the newline.
 ///
 /// # Examples
 //
@@ -52,7 +52,7 @@ pub fn until_eol<I>() -> impl Parser<Input = I, Output = String>
 where I: Stream<Item = char>,
       I::Error: ParseError<I::Item, I::Range, I::Position>
 {
-    ( many1(non_newline()), newline() )
+    ( many1(non_newline()), choice! { newline().map(|_| ()), eof() } )
         .map(|(s, _)| s)
 }
 

--- a/src/scenario.rs
+++ b/src/scenario.rs
@@ -50,10 +50,12 @@ where
     I::Error: ParseError<I::Item, I::Range, I::Position>,
 {
     use combine::char::{newline, string};
-    use combine::{many, token};
+    use combine::{many, token, eof};
 
-    let first_line = (string(prefix), token(' '), inner.clone(), newline()).map(|t| t.2);
-    let and_line = (string("And "), inner, newline()).map(|t| t.1);
+    let line_end = || choice!(newline().map(|_| ()), eof());
+
+    let first_line = (string(prefix), token(' '), inner.clone(), line_end()).map(|t| t.2);
+    let and_line = (string("And "), inner, line_end()).map(|t| t.1);
     (first_line, many(and_line)).map(|(first, mut ands): (BoxedStep<TC>, Vec<BoxedStep<TC>>)| {
         ands.insert(0, first);
         ands
@@ -156,7 +158,7 @@ mod tests {
                  Scenario: Two\n\
                  Given G2\n\
                  When W2\n\
-                 Then T2\n";
+                 Then T2";
 
         use combine::char::digit;
         use combine::token;

--- a/tests/calculator.rs
+++ b/tests/calculator.rs
@@ -127,7 +127,8 @@ mod steps {
 
 #[test]
 fn scenarios() {
-    let spec = r#"Feature: RPN Calculator Arithmetic
+    let spec = r#"
+Feature: RPN Calculator Arithmetic
 The calculator supports basic addition, subtraction, multiplication, and
 division operations.
 
@@ -137,8 +138,7 @@ When I press 1
 And I press enter
 And I press 1
 And I press plus
-Then the display should read 2
-"#;
+Then the display should read 2"#;
 
     use steps::*;
 
@@ -183,7 +183,7 @@ Then the display should read 2
                 when.map(|x| BoxedStep { val: Box::new(x) }),
                 then.map(|x| BoxedStep { val: Box::new(x) })));
 
-    let (f, remaining) = p.easy_parse(State::new(spec)).unwrap();
+    let (f, _) = p.easy_parse(State::new(spec)).unwrap();
 
     let (success, _) = f.eval();
     assert!(success);


### PR DESCRIPTION
Improve the feature and scenario parsers to allow:

 - Blank lines at the beginning of a feature file
 - Multiple blank lines between test cases (scenarios)
 - Missing a newline at the end of the file